### PR TITLE
normalise void zone properly

### DIFF
--- a/Graphs.js
+++ b/Graphs.js
@@ -1595,7 +1595,7 @@ const GraphsConfig = {
 				if (hze > 200) hze = 200
 				if (hze < 80) hze = 80
 				let min = 1000 + ((hze - 80) * 13);
-				return x / min * 2560 // 200 hze value
+				return x * min / 2560 // 200 hze value
 			}
 		}
 	},


### PR DESCRIPTION
consider a run to hze100 and a run to hze200

the run to hze100 will have a delay of 1280, versus the run to hze200's delay of 2560. Thus, aside from the randomness doing random things, the short run will expect twice as many units of void-map-per-zone.

To normalise them, then, the short run should get multiplied by 1/2. that is (min / 2560).

one can see old version behaving wrong in my current last post in the tools channel